### PR TITLE
Refactor: Refactor Adventure of Code Day 7 with Rust

### DIFF
--- a/rust/advent-of-code/src/main.rs
+++ b/rust/advent-of-code/src/main.rs
@@ -134,7 +134,10 @@ fn exec_seven() {
         small_files_size
     );
 
-    println!("Deleted size is {}", deletable_size);
+    println!(
+        "Need to delete {} more before system update",
+        deletable_size
+    );
 }
 
 fn with_benchmark(f: &dyn Fn() -> ()) {

--- a/rust/advent-of-code/src/main.rs
+++ b/rust/advent-of-code/src/main.rs
@@ -124,14 +124,17 @@ fn exec_six() {
 }
 
 fn exec_seven() {
-    let (total_file_size, deleted_file) = seven::day_7_solution();
+    let directory_map = seven::generate_directory_map();
+
+    let small_files_size = seven::sum_small_files(&directory_map);
+    let deletable_size = seven::deletable_size(&directory_map);
 
     println!(
         "Total file size of all files that at most 100_000 is {}",
-        total_file_size
+        small_files_size
     );
 
-    println!("Deleted size is {}", deleted_file);
+    println!("Deleted size is {}", deletable_size);
 }
 
 fn with_benchmark(f: &dyn Fn() -> ()) {

--- a/rust/advent-of-code/src/seven.rs
+++ b/rust/advent-of-code/src/seven.rs
@@ -60,7 +60,7 @@ pub fn generate_directory_map() -> HashMap<String, usize> {
                     Some(dir_size) => *dir_size,
                     None => 0,
                 };
-                dir_size_map.insert(String::from(dir_path), file_size + previous_dir_size);
+                dir_size_map.insert(dir_path, file_size + previous_dir_size);
             }
         }
     }

--- a/rust/advent-of-code/src/seven.rs
+++ b/rust/advent-of-code/src/seven.rs
@@ -4,7 +4,7 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-pub fn day_7_solution() -> (usize, usize) {
+pub fn generate_directory_map() -> HashMap<String, usize> {
     let file = File::open("src/inputs/seven.txt")
         .unwrap_or_else(|err| panic!("Cannot read file with error {:?}", err));
     let reader = BufReader::new(file);
@@ -23,11 +23,11 @@ pub fn day_7_solution() -> (usize, usize) {
         let identifier = tokens.get(0).unwrap();
 
         if identifier.eq("$") {
-            let command = String::from(tokens.get(1).unwrap());
+            let command = tokens.get(1).unwrap();
 
             // Execute command
             if command.eq("cd") {
-                let args = String::from(tokens.get(2).unwrap());
+                let args = tokens.get(2).unwrap();
                 match args.as_str() {
                     "/" => {
                         current_directory.clear();
@@ -46,23 +46,15 @@ pub fn day_7_solution() -> (usize, usize) {
             }
         } else {
             // Read command output
-            if tokens[0].eq("dir") {
+
+            // Skip current line if output if a directory
+            if identifier.eq("dir") {
                 continue;
             }
 
             let file_size: usize = tokens[0].parse().unwrap();
 
             for i in 0..current_directory.len() {
-                if i == 0 {
-                    let root = String::from("/");
-                    let previous_dir_size = match dir_size_map.get(&root) {
-                        Some(dir_size) => *dir_size,
-                        None => 0,
-                    };
-                    dir_size_map.insert(root, file_size + previous_dir_size);
-                    continue;
-                }
-
                 let dir_path = current_directory[0..i + 1].join("/");
                 let previous_dir_size = match dir_size_map.get(&dir_path) {
                     Some(dir_size) => *dir_size,
@@ -73,23 +65,29 @@ pub fn day_7_solution() -> (usize, usize) {
         }
     }
 
+    return dir_size_map;
+}
+
+pub fn sum_small_files(directory_map: &HashMap<String, usize>) -> usize {
     let mut size_sum = 0;
-    for value in dir_size_map.values() {
+    for value in directory_map.values() {
         if *value < 100_000 {
             size_sum += *value;
         }
     }
+    return size_sum;
+}
 
+pub fn deletable_size(directory_map: &HashMap<String, usize>) -> usize {
     let mut valid_file_size: Vec<usize> = vec![];
-    let occupied_space = dir_size_map.get(&String::from("/")).unwrap();
+    let occupied_space = directory_map.get(&String::from("/")).unwrap();
     let required_at_least = occupied_space - 40_000_000;
 
-    for value in dir_size_map.values() {
+    for value in directory_map.values() {
         if *value >= required_at_least {
             valid_file_size.push(*value);
         }
     }
     valid_file_size.sort();
-
-    return (size_sum, valid_file_size[0]);
+    return valid_file_size[0];
 }


### PR DESCRIPTION
- Remove unnecessary `String::from` casting
- Separate solution into multiple functions